### PR TITLE
Fix deprecation warning for ember v2.1.0-beta.1

### DIFF
--- a/app/initializers/export-application-global.js
+++ b/app/initializers/export-application-global.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import config from '../config/environment';
 
-export function initialize(container, application) {
+export function initialize(application) {
   if (config.exportApplicationGlobal !== false) {
     var value = config.exportApplicationGlobal;
     var globalName;

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-export-application-global",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "2.1.0-beta.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.5",
@@ -12,5 +12,8 @@
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
+  },
+  "resolutions": {
+    "ember": "2.1.0-beta.1"
   }
 }

--- a/tests/unit/initializers/export-application-global-test.js
+++ b/tests/unit/initializers/export-application-global-test.js
@@ -30,7 +30,7 @@ module('ExportApplicationGlobalInitializer', {
 test('it sets the application on window with the classified modulePrefix', function(assert) {
   config.modulePrefix = 'foo';
   var app = { reopen: function(){} };
-  initialize(null, app);
+  initialize(app);
 
   assert.equal(window.Foo, app);
 });
@@ -39,7 +39,7 @@ test('it sets the application on window with the classified modulePrefix when ex
   config.modulePrefix = 'foo';
   config.exportApplicationGlobal = true;
   var app = { reopen: function(){} };
-  initialize(null, app);
+  initialize(app);
 
   assert.equal(window.Foo, app);
 });
@@ -48,7 +48,7 @@ test('it does not set the global unless exportApplicationGlobal is true', functi
   config.modulePrefix = 'foo';
   config.exportApplicationGlobal = false;
   var app = { reopen: function(){} };
-  initialize(null, app);
+  initialize(app);
 
   assert.ok(window.Foo !== app);
 });
@@ -65,7 +65,7 @@ test('it sets a custom global name if specified', function(assert) {
   config.modulePrefix = 'foo';
   config.exportApplicationGlobal = 'Catz';
   var app = { reopen: function(){} };
-  initialize(null,  app);
+  initialize(app);
 
   assert.ok(window.Foo !== app);
   assert.ok(window.Catz === app);


### PR DESCRIPTION
Fixes deprecation warning for `[deprecation id: ember-application.app-initializer-initialize-arguments]`.