### PR TITLE
Update Ember to stable 2.1 version. Remove deprecations.

### DIFF
--- a/app/initializers/export-application-global.js
+++ b/app/initializers/export-application-global.js
@@ -17,14 +17,14 @@ export function initialize() {
       window[globalName] = application;
 
       application.reopen({
-        willDestroy: function(){
+        willDestroy: function() {
           this._super.apply(this, arguments);
           delete window[globalName];
         }
       });
     }
   }
-};
+}
 
 export default {
   name: 'export-application-global',

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,14 @@
 {
   "name": "ember-export-application-global",
   "dependencies": {
-    "ember": "2.0.2",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
+    "ember": "2.1.0",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.6",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
-  },
-  "resolutions": {
-    "ember": "2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.3.3",
+    "ember-cli-app-version": "1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",


### PR DESCRIPTION
Update Ember to stable 2.1 version. Remove deprecations.

Some dependencies have been updated. Here's why:

- App version was throwing deprecations (4?) inside tests
- To remove Ember 2.x resolution in bower

Comma has been deleted because linter was throwing an 'unneeded comma' error.

cc @stefanpenner, @rwjblue