### PR TITLE
Update to Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/ember-cli/ember-export-application-global.git"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Robert Jackson <me@rwjblue.com>",
   "license": "MIT",
@@ -25,7 +25,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-qunit": "^2.1.0",
     "ember-cli-release": "^0.2.9",
@@ -39,7 +39,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.0.0-beta.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.