### PR TITLE
Drop Node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/ember-cli/ember-export-application-global.git"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "author": "Robert Jackson <me@rwjblue.com>",
   "license": "MIT",


### PR DESCRIPTION
... because Node 4 is no longer maintained by the Node.js team and several dependency updates are blocked because we still support Node 4.

This PR will require a new major version release.