### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,11 @@
   "license": "MIT",
   "devDependencies": {
     "ember-cli": "2.8.0",
-    "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-qunit": "^2.1.0",
-    "ember-cli-release": "^0.2.9",
     "ember-cli-test-loader": "^1.1.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-load-initializers": "^0.5.1",


### PR DESCRIPTION
We don't deploy the dummy app anywhere so these dependencies are not used anywhere.