### PR TITLE
Remove ember-cli-babel dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - yarn global add bower
 
 install:
-  - yarn install --no-lockfile --non-interactive
+  - yarn install --no-lockfile --non-interactive --ignore-engines
   - bower install
 
 script:

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   "bugs": {
     "url": "https://github.com/ember-cli/ember-export-application-global/issues"
   },
-  "homepage": "https://github.com/ember-cli/ember-export-application-global"
+  "homepage": "https://github.com/ember-cli/ember-export-application-global",
+  "resolutions": {
+    "**/engine.io": "~3.3.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "ember-cli": "~3.9.0",
+    "ember-cli-babel": "^7.11.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^3.1.0",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
@@ -36,9 +37,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "dependencies": {
-    "ember-cli-babel": "^7.11.0"
-  },
+  "dependencies": { },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,7 +3198,7 @@ engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-engine.io@~3.3.1:
+engine.io@~3.3.0, engine.io@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.3.2.tgz#18cbc8b6f36e9461c5c0f81df2b830de16058a59"
   integrity sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==


### PR DESCRIPTION
Since this addon has no code in `addon/` or `addon-test-support/` we do not need a hard dependency on `ember-cli-babel` and it can be a dev dependency just fine.